### PR TITLE
Expose modal props in useModal

### DIFF
--- a/src/use-modal.ts
+++ b/src/use-modal.ts
@@ -125,5 +125,6 @@ export const useModal = () => {
     vnode,
     close,
     redirect,
+    props,
   }
 }


### PR DESCRIPTION
Would be easier to use modal props with `const {props} = useModal();` rather than `usePage().props.value.modal.props`