### PR TITLE
Add "type": "module" to package.json for Vite resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "main": "./dist/momentum-modal.umd.js",
   "module": "./dist/momentum-modal.es.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
This is related to https://github.com/lepikhinb/momentum-modal/issues/17.

The `package.json` is missing a `"type": "module"` key which tells Vite to treat the module as an ES module. This means that Vite will import the ES module build but then try and interpret it as a CommonJS module which leads to the whole `Cannot use import statement outside a module` business.

I am aware that the example project has working a SSR setup using this package. I'm unsure what exactly is different between the example project and mine but I don't really have the energy to figure out. Trying to understand JavaScript's million different module systems leads to insanity.

FWIW, this is how [headlessui](https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-vue/package.json#L18) does it as well.