### PR TITLE
Add options property to useModal()-helper

### DIFF
--- a/src/use-modal.ts
+++ b/src/use-modal.ts
@@ -3,6 +3,7 @@ import { router } from "@inertiajs/vue3"
 import { defineAsyncComponent, h, nextTick, watch, computed, ref, shallowRef } from "vue"
 import axios from "axios"
 import resolver from "./resolver"
+import { GlobalEventCallback, Visit } from "@inertiajs/core"
 
 const modal = computed(() => usePage()?.props?.modal)
 const props = computed(() => modal.value?.props)
@@ -95,7 +96,20 @@ watch(
 
 watch(key, updateHeaders)
 
-const redirect = () => {
+export type RedirectOptions = Partial<
+  Visit & {
+    onCancelToken: ({ cancel }: { cancel: VoidFunction }) => void
+    onBefore: GlobalEventCallback<"before">
+    onStart: GlobalEventCallback<"start">
+    onProgress: GlobalEventCallback<"progress">
+    onFinish: GlobalEventCallback<"finish">
+    onCancel: GlobalEventCallback<"cancel">
+    onSuccess: GlobalEventCallback<"success">
+    onError: GlobalEventCallback<"error">
+  }
+>
+
+const redirect = (redirectOptions?: RedirectOptions) => {
   var redirectURL = modal.value?.redirectURL ?? modal.value?.baseURL
 
   vnode.value = false
@@ -106,16 +120,17 @@ const redirect = () => {
 
   return router.visit(redirectURL, {
     preserveScroll: true,
-    preserveState: true,
+    preserveState: false,
+    ...redirectOptions,
   })
 }
 
-export const useModal = () => {
+export const useModal = (redirectOptions?: RedirectOptions) => {
   return {
     show,
     vnode,
     close,
-    redirect,
+    redirect: () => redirect(redirectOptions),
     props,
   }
 }


### PR DESCRIPTION
I use modals to display a dish in a menu. The modal contains more information about the dish and allows to add the dish to the shopping cart. In this case, it is not desirable for the modal to end up in the browser history. I tried several ways, but I couldn't get around it.

The solution: Adding a "redirectOptions" property in the useModal()->hook, which allows setting the options for the redirect function and use it like this:


**Modal.vue**
```js
<script lang="ts" setup>
import {
    Dialog,
    DialogDescription,
    DialogPanel,
    DialogTitle,
    TransitionChild,
    TransitionRoot,
} from "@headlessui/vue";

import { useModal } from "momentum-modal";

const props = defineProps({
  redirectReplace: {
    type: Boolean,
    default: false,
  },
})

const { show, close, redirect } = useModal({
    replace: props.redirectReplace,
});
</script>

<template>
 <TransitionRoot :show="show" as="template">
  <Dialog as="div" class="relative z-30" @close="close">
    <TransitionChild
     @after-leave="redirect"
     ...
    >
      ...
   </TransitionChild>
  </Dialog>
 </TransitionRoot>
</template>
```

By setting replace to true by visiting the modal and setting redirect-replace in the model itself, it works great:

```js
<Link :href="route('my-model-route')" replace>Open modal</Link>
```

**CustomModal.vue**
```html
<script lang="ts" setup>
import Modal from "../Modal.vue";
</script>

<template>
 <Modal redirect-replace>
   <p>This is a text</p>
 </Modal>
</template>
```
