### PR TITLE
Fix memory leak with usePage

### DIFF
--- a/src/use-modal.ts
+++ b/src/use-modal.ts
@@ -4,7 +4,8 @@ import { defineAsyncComponent, h, nextTick, watch, computed, ref, shallowRef } f
 import axios from "axios"
 import resolver from "./resolver"
 
-const modal = computed(() => usePage()?.props?.modal)
+const page = usePage()
+const modal = computed(() => page?.props?.modal)
 const props = computed(() => modal.value?.props)
 const key = computed(() => modal.value?.key)
 


### PR DESCRIPTION
This PR fixes a memory leak caused by `usePage` usage inside a computed property (see https://github.com/inertiajs/inertia/issues/1602)

### Steps to reproduce

1. Install momentum-modal/momentum-modal-plugin as per readme
2. Build for SSR and start profiling with `clinic doctor -- node bootstrap/ssr/ssr.js`
3. Send traffic with `ab -n 2000 -c 1 https://site.test`

This results in memory not being cleared up.

<img width="587" alt="Screenshot 2024-03-06 at 11 07 19" src="https://github.com/lepikhinb/momentum-modal-plugin/assets/1692996/b8e777da-2593-40b2-b6b2-3ec0813485b2">

### After fix

After moving `usePage`, running the same steps produces the following. Memory is correctly cleared.

<img width="589" alt="Screenshot 2024-03-06 at 11 14 57" src="https://github.com/lepikhinb/momentum-modal-plugin/assets/1692996/4c7a7c24-cb56-4abd-8996-16032e2daabd">