### PR TITLE
Typescript import fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/momentum-modal.js",
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/momentum-modal.js"
+      },
       "require": "./dist/momentum-modal.umd.cjs"
     }
   },


### PR DESCRIPTION
I use Laravel 11, with Sail, Vite, Inertia, Tyepscript.

The `vue-tsc` command was complaing that it was not able to find the types.

```
> sail npx vue-tsc --traceResolution
resources/js/Layout/Main.vue:103:23 - error TS7016: Could not find a declaration file for module 'momentum-modal'. '/var/www/html/node_modules/momentum-modal/dist/momentum-modal.js' implicitly has an 'any' type.
  There are types at '/var/www/html/node_modules/momentum-modal/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'momentum-modal' library may need to update its package.json or typings.

103 import { Modal } from 'momentum-modal';
                          ~~~~~~~~~~~~~~~~


Found 1 error in resources/js/Layout/Main.vue:103
```

It looked like it needed an extra file listed in package.json, and since it fixed the issue for me I created a fork to be able to install it from git and I thought I bring this to your attention with this pull request.

I only added this to the import section, because I'm using imports only and that's what I could validate working.

Feel free to merge this or use it for a bigger change, you probably know better if any more modifications need to be done or not.